### PR TITLE
Fixing documentation for default litestream version

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you rebuild the Docker image from source, you can adjust the build behavior w
 
 | Build Arg | Meaning | Default Value |
 | --------- | ------- | ------------- |
-| `litestream_version` | Version of [Litestream](https://litestream.io/) to use for data replication | `0.3.3` |
+| `litestream_version` | Version of [Litestream](https://litestream.io/) to use for data replication | `0.3.4` |
 
 ## Deployment
 


### PR DESCRIPTION
It changed to 0.3.4 in #101