### PR TITLE
Limit maximum request size in pastePut

### DIFF
--- a/handlers/paste.go
+++ b/handlers/paste.go
@@ -46,7 +46,7 @@ func (s defaultServer) pastePut() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 
-		bodyRaw, err := ioutil.ReadAll(r.Body)
+		bodyRaw, err := ioutil.ReadAll(http.MaxBytesReader(w, r.Body, MaxPasteCharacters))
 		if err != nil {
 			log.Printf("Error reading body: %v", err)
 			http.Error(w, "can't read request body", http.StatusBadRequest)


### PR DESCRIPTION
Without this, clients can upload arbitrarily-large pastes. Such pastes will be caught later by `validatePaste`, but in the interim, the entire paste is held in memory, so a malicious client could trivially pipe `/dev/urandom` into `curl` and eventually cause your server to OOM.