### PR TITLE
Update to litestream 0.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN go build \
 
 FROM debian:stable-20210208-slim
 
-ARG litestream_version="0.3.4"
+ARG litestream_version="0.3.5"
 ARG litestream_deb_filename="litestream-v${litestream_version}-linux-amd64.deb"
 
 RUN set -x && \

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If you rebuild the Docker image from source, you can adjust the build behavior w
 
 | Build Arg | Meaning | Default Value |
 | --------- | ------- | ------------- |
-| `litestream_version` | Version of [Litestream](https://litestream.io/) to use for data replication | `0.3.4` |
+| `litestream_version` | Version of [Litestream](https://litestream.io/) to use for data replication | `0.3.5` |
 
 ## Deployment
 

--- a/docker_entrypoint
+++ b/docker_entrypoint
@@ -64,11 +64,12 @@ if [[ "${IS_LITESTREAM_ENABLED}" == 'true' ]]; then
   # Restore database from S3.
   litestream restore -if-replica-exists -v "${DB_PATH}"
 
-  # Begin replication to S3 in the background.
-  # Note: It would be nicer to use the systemd service, but systemd
-  # is trickier within Docker.
-  litestream replicate "${DB_PATH}" "${DB_REPLICA_URL}" &
+  # Let Litestream start LogPaste as a child process
+  exec litestream replicate \
+    -exec "/app/server $(env_vars_to_flags)"
+    "${DB_PATH}" \
+    "${DB_REPLICA_URL}"
+else
+  # Start server.
+  eval "/app/server $(env_vars_to_flags)"
 fi
-
-# Start server.
-eval "/app/server $(env_vars_to_flags)"


### PR DESCRIPTION
Take advantage of litestream's newer Docker-friendly -exec flag to avoid the hacky background process stuff we were doing before.