### PR TITLE
Fix --skip-build option in e2e test script

### DIFF
--- a/dev-scripts/run-e2e-tests
+++ b/dev-scripts/run-e2e-tests
@@ -21,4 +21,4 @@ COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 \
   docker-compose up \
     --exit-code-from cypress \
     --abort-on-container-exit \
-    "${EXTRA_FLAGS}"
+    ${EXTRA_FLAGS}


### PR DESCRIPTION
Apparently the quotes break the docker-compose call, so this removes the quotes around the env variable.