### PR TITLE
Exercise litestream in e2e test

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -2,8 +2,6 @@ version: "3.2"
 services:
   test_sftp:
     image: emberstack/sftp:build-5.0.3
-    ports:
-      - "8022:22"
     volumes:
       - ./sftp.json:/app/config/sftp.json:ro
   logpaste:
@@ -11,7 +9,7 @@ services:
       context: ../
     environment:
       - PORT=3333
-      - DB_REPLICA_URL="sftp://dummyuser:dummypass@test_sftp:8022/sftp"
+      - DB_REPLICA_URL="sftp://dummyuser:dummypass@test_sftp"
     volumes:
       - ./:/app/e2e
     depends_on:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -12,9 +12,6 @@ services:
     environment:
       - PORT=3333
       - DB_REPLICA_URL="sftp://dummyuser:dummypass@test_sftp:8022/sftp"
-      - LITESTREAM_ACCESS_KEY_ID="dummyaccesskeyid"
-      - LITESTREAM_SECRET_ACCESS_KEY="dummysecretaccesskey"
-      - LITESTREAM_REGION="dummyregion"
     volumes:
       - ./:/app/e2e
     depends_on:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -7,6 +7,8 @@ services:
   logpaste:
     build:
       context: ../
+    entrypoint: /app/e2e/wait-for-sftp.bash
+    command: ["test_sftp", "22", "--", "/app/docker_entrypoint"]
     environment:
       - PORT=3333
       - DB_REPLICA_URL="sftp://dummyuser:dummypass@test_sftp"

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,12 +1,24 @@
 version: "3.2"
 services:
+  test_sftp:
+    image: emberstack/sftp:build-5.0.3
+    ports:
+      - "8022:22"
+    volumes:
+      - ./sftp.json:/app/config/sftp.json:ro
   logpaste:
     build:
       context: ../
     environment:
       - PORT=3333
+      - DB_REPLICA_URL="sftp://dummyuser:dummypass@test_sftp:8022/sftp"
+      - LITESTREAM_ACCESS_KEY_ID="dummyaccesskeyid"
+      - LITESTREAM_SECRET_ACCESS_KEY="dummysecretaccesskey"
+      - LITESTREAM_REGION="dummyregion"
     volumes:
       - ./:/app/e2e
+    depends_on:
+      - test_sftp
   cypress:
     image: "mtlynch/cypress:8.1.0-chrome91"
     command: ["--browser", "chrome"]

--- a/e2e/sftp.json
+++ b/e2e/sftp.json
@@ -8,8 +8,8 @@
   },
   "Users": [
     {
-      "Username": "demouser",
-      "Password": "demopass"
+      "Username": "dummyuser",
+      "Password": "dummypass"
     }
   ]
 }

--- a/e2e/sftp.json
+++ b/e2e/sftp.json
@@ -1,0 +1,15 @@
+{
+  "Global": {
+    "Chroot": {
+      "Directory": "%h",
+      "StartPath": "sftp"
+    },
+    "Directories": ["sftp"]
+  },
+  "Users": [
+    {
+      "Username": "demouser",
+      "Password": "demopass"
+    }
+  ]
+}

--- a/e2e/wait-for-sftp.bash
+++ b/e2e/wait-for-sftp.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+SFTP_HOST="$1"
+shift
+SFTP_PORT="$1"
+shift
+
+timeout 15 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' "${SFTP_HOST}" "${SFTP_PORT}"
+
+>&2 echo "sftp is up - executing command"
+
+exec "$@"


### PR DESCRIPTION
#129 slipped through because logpaste doesn't use litestream in the e2e test. This is only a light test on litestream as it doesn't verify that backups are actually *working*, but it's at least good to verify that we can launch the binary successfully.