### PR TITLE
Use DB_REPLICA_URL to determine if Litestream is enabled

### DIFF
--- a/docker_entrypoint
+++ b/docker_entrypoint
@@ -45,9 +45,7 @@ is_litestream_enabled() {
 
   local IS_ENABLED='false'
 
-  if [[ ! -z "${LITESTREAM_ACCESS_KEY_ID}" ]] && \
-      [[ ! -z "${LITESTREAM_SECRET_ACCESS_KEY}" ]] && \
-      [[ ! -z "${LITESTREAM_REGION}" ]]; then
+  if [[ ! -z "${DB_REPLICA_URL}" ]]; then
     IS_ENABLED='true';
   fi
 


### PR DESCRIPTION
We were previously using environment variables related to Litestream's S3 replica, but that's a brittle way to check, since sftp doesn't rely on any S3 variables. Using DB_REPLICA_URL gives a more reliable answer as to whether the configuration relies on Litestream.

Related: #133