### PR TITLE
Use fly.io builder for deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,6 @@ jobs:
           name: Deploy logpaste to fly.io
           command: |
             "${HOME}/.fly/bin/flyctl" deploy \
-              --local-only \
               --env "SITE_FOOTER=<h2>Notice</h2><p>This is a demo instance. Uploads are wiped every few hours.</p>"
 
   build_docker_images:


### PR DESCRIPTION
Fly.io builders have gotten more stable over the years, so we can use those now instead of building in CI.