### PR TITLE
Rename PS_BEHIND_PROXY to LP_BEHIND_PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can adjust behavior of the Docker container by passing these parameters with
 | Environment Variable           | Meaning                                                                                           |
 | ------------------------------ | ------------------------------------------------------------------------------------------------- |
 | `PORT`                         | TCP port on which to listen for HTTP connections (defaults to 3001)                               |
-| `PS_BEHIND_PROXY`              | Set to `y` if running behind an HTTP proxy to improve logging                                     |
+| `LP_BEHIND_PROXY`              | Set to `y` if running behind an HTTP proxy to improve logging                                     |
 | `DB_REPLICA_URL`               | S3 URL where you want to replicate the LogPaste datastore (e.g., `s3://mybucket.mydomain.com/db`) |
 | `LITESTREAM_REGION`            | AWS region where your S3 bucket is located                                                        |
 | `LITESTREAM_ACCESS_KEY_ID`     | AWS access key ID for an IAM role with access to the bucket where you want to replicate data.     |

--- a/cmd/logpaste/main.go
+++ b/cmd/logpaste/main.go
@@ -37,7 +37,7 @@ func main() {
 		FooterHTML: *footer,
 		ShowDocs:   *showDocs,
 	}, *perMinuteLimit, maxCharLimit).Router())
-	if os.Getenv("PS_BEHIND_PROXY") != "" {
+	if os.Getenv("LP_BEHIND_PROXY") != "" {
 		h = gorilla.ProxyIPHeadersHandler(h)
 	}
 	http.Handle("/", h)

--- a/dev-scripts/make-fly-config
+++ b/dev-scripts/make-fly-config
@@ -46,7 +46,7 @@ kill_timeout = 5
 
 [env]
   PORT = "3001"
-  PS_BEHIND_PROXY="yes"
+  LP_BEHIND_PROXY="yes"
 
 [build]
   image = "mtlynch/logpaste"

--- a/docs/deployment/cloud-run.md
+++ b/docs/deployment/cloud-run.md
@@ -88,7 +88,7 @@ MAX_INSTANCES="1"
 gcloud beta run deploy \
   "${GCR_SERVICE_NAME}" \
   --image "${LOGPASTE_GCR_URL}" \
-  --set-env-vars "DB_REPLICA_URL=gcs://${GCS_BUCKET}/db PS_BEHIND_PROXY=y" \
+  --set-env-vars "DB_REPLICA_URL=gcs://${GCS_BUCKET}/db LP_BEHIND_PROXY=y" \
   --allow-unauthenticated \
   --region "${GCP_REGION}" \
   --execution-environment gen2 \

--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -45,7 +45,7 @@ heroku apps:create "${APP_NAME}" --stack container
 Assign all the relevant environment variables to your app:
 
 ```bash
-heroku config:set --app "${APP_NAME}" PS_BEHIND_PROXY="y"
+heroku config:set --app "${APP_NAME}" LP_BEHIND_PROXY="y"
 heroku config:set --app "${APP_NAME}" LITESTREAM_ACCESS_KEY_ID="${LITESTREAM_ACCESS_KEY_ID}"
 heroku config:set --app "${APP_NAME}" LITESTREAM_SECRET_ACCESS_KEY="${LITESTREAM_SECRET_ACCESS_KEY}"
 heroku config:set --app "${APP_NAME}" LITESTREAM_REGION="${LITESTREAM_REGION}"

--- a/docs/deployment/lightsail.md
+++ b/docs/deployment/lightsail.md
@@ -51,7 +51,7 @@ Enter the following information for your custom deployment:
 | Key                            | Value                                               |
 | ------------------------------ | --------------------------------------------------- |
 | `PORT`                         | 3001                                                |
-| `PS_BEHIND_PROXY`              | "y"                                                 |
+| `LP_BEHIND_PROXY`              | "y"                                                 |
 | `DB_REPLICA_URL`               | The S3 URL of your S3 bucket                        |
 | `LITESTREAM_REGION`            | The region of your S3 bucket                        |
 | `LITESTREAM_ACCESS_KEY_ID`     | The AWS access key ID from your IAM credentials     |

--- a/handlers/paste.go
+++ b/handlers/paste.go
@@ -196,7 +196,7 @@ func anyFileInForm(formFiles map[string][]*multipart.FileHeader) (multipart.File
 func baseURLFromRequest(r *http.Request) string {
 	var scheme string
 	// If we're running behind a proxy, assume that it's a TLS proxy.
-	if r.TLS != nil || os.Getenv("PS_BEHIND_PROXY") != "" {
+	if r.TLS != nil || os.Getenv("LP_BEHIND_PROXY") != "" {
 		scheme = "https"
 	} else {
 		scheme = "http"


### PR DESCRIPTION
PS_ was accidentally inherited from PicoShare. LogPaste should have its own short prefix.