### PR TITLE
Handle quoted strings correctly in docker image

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -27,7 +27,11 @@ readonly IS_LITESTREAM_ENABLED
 set -x
 
 
-LP_LAUNCH_CMD="/app/logpaste $*"
+# Ensure that arguments stay quoted.
+LP_LAUNCH_CMD="/app/logpaste"
+for arg in "$@"; do
+  LP_LAUNCH_CMD="${LP_LAUNCH_CMD} $(printf '%q' "$arg")"
+done
 
 if [[ "${IS_LITESTREAM_ENABLED}" == 'true' ]]; then
   /app/litestream version


### PR DESCRIPTION
Fixes a bug where we were accidentally dropping quotes in quoted strings for arguments in the docker image.

Resolves #220